### PR TITLE
Added condition to handle .go files detected as Go language type

### DIFF
--- a/main.js
+++ b/main.js
@@ -136,7 +136,8 @@ define(function (require, exports, module) {
             showErrorDialog(Strings.ERROR_NO_CURRENT_FILE);
             return;
         }
-        if (currentDocument.language._name !== 'Golang') {
+        if ((currentDocument.language._name !== 'Golang') &&
+            (currentDocument.language._name !== 'Go')) {
             showErrorDialog(Strings.ERROR_NOT_GO_FILE, {language: currentDocument.language._name});
             return;
         }


### PR DESCRIPTION
Brackets version:
Release 1.8 experimental build 1.8.0-17108 (alf_localization_release_1.8 3af64fae4) 
build timestamp: Wed Nov 09 2016 02:47:52 GMT+0000

bokub/brackets-gofmt version:
1.2.0

Description:
When I open a .go file, Brackets detects the language type as "Go", not "Golang". When I attempt to format the .go file with the gofmt extension the following error dialog pops up:

Go Formatter error

The current file is a Go file.
Go Formatter can format Go files only.

Proposed change:
I added another condition to handle the document language name Go in addition to Golang in main.js on line 139.
